### PR TITLE
Add an option to configure without django

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ STATSD_INFLUX_HOST = 'localhost',
 STATSD_INFLUX_PORT = '8125',
 ```
 
+###Non-django configuration
+This package can also be configured without django by running
+```python
+import influx
+influx.configure(STATSD_INFLUX_HOST, STATSD_INFLUX_PORT, PROJECT_NAME)
+```
+
 ###Statsd Metric Format
 ```python
 PROJECT_NAME.{metric_name},host=HOSTNAME,tag=value

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
     keywords=['statsd', 'influx', 'influxdb', 'django'],
     install_requires=[
         'statsd==3.2.1',
-        'Django>=1.8.4'
     ],
     tests_require=['tox', 'virtualenv', 'statsd==3.2.1', 'Django>=1.8.4'],
     cmdclass={'test': Tox},

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ class Tox(TestCommand):
 setup(
     name='django-statsd-influx',
     packages=['influx'],
-    version='0.1',
+    version='0.1.3',
     description='Django Statsd Influx Client ',
     author='Jure Ham, Zemanta',
     author_email='jure.ham@zemanta.com',


### PR DESCRIPTION
Adding an option to configure package in projects that don't use django. In this case settings have to be configured manually.
