### PR TITLE
Add timing method

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+machine:
+  post:
+    - pyenv global 2.7.11 3.6.0
+
+test:
+    override:
+        - 'python setup.py test'

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     install_requires=[
         'statsd==3.2.1',
     ],
-    tests_require=['tox', 'virtualenv', 'statsd==3.2.1', 'Django>=1.8.4'],
+    tests_require=['tox', 'virtualenv', 'statsd==3.2.1'],
     cmdclass={'test': Tox},
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
-envlist = py27,py34
+envlist = py27,py36
 [testenv]
 deps=
   statsd==3.2.1
-  Django>=1.8.4
   nose==1.3.7
 commands=nosetests


### PR DESCRIPTION
Add timing method so you can manually pass the elapsed seconds. Useful in situations when you can't use a decorator or a block timer.